### PR TITLE
tweak to table header

### DIFF
--- a/assets/styles/hot-design-system/_tables.scss
+++ b/assets/styles/hot-design-system/_tables.scss
@@ -25,7 +25,8 @@
   }
 
   thead th {
-    @extend .heading-alt;
+    text-transform: uppercase;
+    font-weight: 400;
     font-size: 0.875rem;
     line-height: 1.25rem;
     vertical-align: bottom;

--- a/assets/styles/hot-design-system/_tables.scss
+++ b/assets/styles/hot-design-system/_tables.scss
@@ -26,7 +26,7 @@
 
   thead th {
     text-transform: uppercase;
-    font-weight: 400;
+    font-weight: $base-font-regular;
     font-size: 0.875rem;
     line-height: 1.25rem;
     vertical-align: bottom;


### PR DESCRIPTION
Tweak to table header to not inherit from header-alt which makes it grey. 

As requested by @bgirardot 